### PR TITLE
Updates for AD1 project compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,32 +56,37 @@ group :development do
   gem "web-console"
 end
 
-# Additional gems for AppDev 2
+# Additional gems for AppDev
 gem "active_link_to"
+gem "appdev_support"
 gem "awesome_print"
+gem "devise"
 gem "dotenv"
+gem "carrierwave"
+gem "cloudinary"
 gem "faker"
 gem "htmlbeautifier"
 gem "http"
-gem "table_print"
-gem "simple_form"
-gem "devise"
+gem "kaminari"
+gem "openai-chat"
 gem "pundit"
 gem "ransack"
+gem "simple_form"
 gem "strip_attributes"
+gem "table_print"
 gem "validate_url"
-gem "carrierwave"
-gem "cloudinary"
-gem "kaminari"
 
 group :development do
   gem "annotaterb"
   gem "better_errors"
   gem "binding_of_caller"
+  gem "dev_toolbar", "~> 2.1.0"
+  gem "draft_generators"
+  gem "haikunator"
   gem "pry-rails"
+  gem "rails_db", "~> 2.5.0"
   gem "rails-erd"
   gem "rufo"
-  gem "haikunator"
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ gem "pundit"
 gem "ransack"
 gem "simple_form"
 gem "strip_attributes"
-gem "table_print"
 gem "validate_url"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     annotaterb (4.14.0)
+    appdev_support (0.2.1)
+      tabulo
     ast (2.4.2)
     awesome_print (1.9.2)
     base64 (0.2.0)
@@ -128,11 +130,14 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    csv (3.3.5)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
     debug_inspector (1.2.0)
+    dev_toolbar (2.1.0)
+      rails (>= 7.0)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -142,6 +147,9 @@ GEM
     diff-lcs (1.6.0)
     domain_name (0.6.20240107)
     dotenv (3.1.7)
+    draft_generators (0.0.4)
+      devise
+      indefinite_article
     drb (2.2.1)
     ed25519 (1.3.0)
     erubi (1.13.1)
@@ -204,6 +212,8 @@ GEM
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
+    indefinite_article (0.2.5)
+      activesupport
     io-console (0.8.0)
     irb (1.15.1)
       pp (>= 0.6.0)
@@ -253,6 +263,10 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0701)
     mini_magick (5.2.0)
       benchmark
       logger
@@ -297,6 +311,8 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     oj (3.13.23)
+    openai-chat (0.0.6)
+      mime-types (~> 3.0)
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     parallel (1.26.3)
@@ -365,6 +381,14 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_db (2.5.0)
+      activerecord
+      csv
+      kaminari
+      rails (>= 5.0.0)
+      ransack (>= 2.3.2)
+      simple_form (>= 5.0.1)
+      terminal-table
     railties (8.0.2)
       actionpack (= 8.0.2)
       activesupport (= 8.0.2)
@@ -491,6 +515,11 @@ GEM
     strip_attributes (2.0.0)
       activemodel (>= 3.0, < 9.0)
     table_print (1.5.7)
+    tabulo (3.0.3)
+      tty-screen (= 0.8.2)
+      unicode-display_width (~> 3.0)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     thor (1.3.2)
     thruster (0.1.12)
     thruster (0.1.12-aarch64-linux)
@@ -498,6 +527,7 @@ GEM
     thruster (0.1.12-x86_64-darwin)
     thruster (0.1.12-x86_64-linux)
     timeout (0.4.3)
+    tty-screen (0.8.2)
     turbo-rails (2.0.13)
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
@@ -547,6 +577,7 @@ PLATFORMS
 DEPENDENCIES
   active_link_to
   annotaterb
+  appdev_support
   awesome_print
   better_errors
   binding_of_caller
@@ -556,8 +587,10 @@ DEPENDENCIES
   carrierwave
   cloudinary
   debug
+  dev_toolbar (~> 2.1.0)
   devise
   dotenv
+  draft_generators
   faker
   grade_runner (~> 0.0.13)
   haikunator
@@ -567,6 +600,7 @@ DEPENDENCIES
   jbuilder
   kamal
   kaminari
+  openai-chat
   pg (~> 1.1)
   propshaft
   pry-rails
@@ -575,6 +609,7 @@ DEPENDENCIES
   rails (~> 8.0.2)
   rails-controller-testing
   rails-erd
+  rails_db (~> 2.5.0)
   ransack
   rspec-html-matchers
   rspec-rails (~> 7.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -514,7 +514,6 @@ GEM
     stringio (3.1.5)
     strip_attributes (2.0.0)
       activemodel (>= 3.0, < 9.0)
-    table_print (1.5.7)
     tabulo (3.0.3)
       tty-screen (= 0.8.2)
       unicode-display_width (~> 3.0)
@@ -623,7 +622,6 @@ DEPENDENCIES
   solid_queue
   stimulus-rails
   strip_attributes
-  table_print
   thruster
   turbo-rails
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rails-8-template
 
-For your AppDev-2 Projects!
+For your AppDev Projects!
 
 Some rights reserved — see [LICENSE.txt](LICENSE.txt)

--- a/config/initializers/appdev_support.rb
+++ b/config/initializers/appdev_support.rb
@@ -1,0 +1,7 @@
+AppdevSupport.config do |config|
+  config.action_dispatch = true
+  config.active_record   = true
+  config.pryrc           = :minimal
+end
+
+AppdevSupport.init

--- a/config/initializers/dev_toolbar.rb
+++ b/config/initializers/dev_toolbar.rb
@@ -1,0 +1,9 @@
+if Rails.env.development?
+  DevToolbar.configure do |config|
+    config.links = [
+      { name: "Routes", path: "/rails/info/routes" },
+      { name: "Database", path: "/rails/db" },
+      { name: "ERD", path: "/erd" }
+    ]
+  end
+end

--- a/config/initializers/rails_db.rb
+++ b/config/initializers/rails_db.rb
@@ -1,0 +1,30 @@
+if Object.const_defined?("RailsDb")
+  RailsDb.setup do |config|
+    # # enabled or not
+    # config.enabled = Rails.env.development?
+
+    # # automatic engine routes mounting
+    # config.automatic_routes_mount = true
+
+    # set tables which you want to hide ONLY
+    config.black_list_tables = [ "ar_internal_metadata", "solid_cable_messages", "solid_cache_entries", "solid_queue_blocked_executions", "solid_queue_claimed_executions", "solid_queue_failed_executions", "solid_queue_jobs", "solid_queue_pauses", "solid_queue_processes", "solid_queue_ready_executions", "solid_queue_recurring_executions", "solid_queue_recurring_tasks", "solid_queue_scheduled_executions", "solid_queue_semaphores" ]
+
+    # set tables which you want to show ONLY
+    # config.white_list_tables = ['posts', 'comments']
+
+    # # Enable http basic authentication
+    # config.http_basic_authentication_enabled = false
+
+    # # Enable http basic authentication
+    # config.http_basic_authentication_user_name = 'rails_db'
+
+    # # Enable http basic authentication
+    # config.http_basic_authentication_password = 'password'
+
+    # # Enable verify access proc
+    # config.verify_access_proc = proc { |controller| true }
+
+    # # Sandbox mode (only read-only operations)
+    # config.sandbox = false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,4 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  # This is a blank app! Pick your first screen, build out the RCAV, and go from there. E.g.:
+  # get("/your_first_screen", { :controller => "pages", :action => "first" })
 end


### PR DESCRIPTION
Resolves #2 

- Fixed dev_toolbar: https://github.com/firstdraft/dev_toolbar/pull/17
- Fixed rails_db: https://github.com/igorkasyanchuk/rails_db/pull/145

This template will continue working fine for phase 2 projects, no need to test those.

To test a Phase 1 project: pick one, add the `spec/` files (just the specs, not the support files), and, in a codespace on this branch, try to match the target and get specs to pass.

## TODO

When this is approved, the updates should actually be made to the `project-syncing` repository so they are propagated to all the projects that were already built on this template.

We will then iteratively during Summer School, as we need each project, port the Phase 1 project code (currently all based on the Rails 7 template) to this template here.