### PR TITLE
Run Puma in single mode on Render free tier

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -11,7 +11,12 @@ services:
         sync: false
       # Memory optimization for Render free tier (512MB RAM)
       - key: WEB_CONCURRENCY
-        value: "1" # Single worker to fit in 512MB
+        # 0 = Puma single mode (the master process serves HTTP directly,
+        # no forked workers). Any value ≥ 1 spawns that many worker
+        # processes on top of the master, each adding ~150MB. Combined
+        # with the four Solid Queue subprocesses below, anything above
+        # single mode OOMs on the 512MB free tier.
+        value: "0"
       - key: RAILS_MAX_THREADS
         value: "3" # Cap threads to reduce memory
       - key: MALLOC_ARENA_MAX


### PR DESCRIPTION
## Summary
\`WEB_CONCURRENCY=1\` was set in \`render.yaml\` with the comment _"Single worker to fit in 512MB"_, but that's the opposite of what it does. \`WEB_CONCURRENCY\` is the number of workers Puma forks **in addition to** the master, so \`1\` means master + 1 worker = 2 Puma processes in cluster mode.

Combined with \`SOLID_QUEUE_IN_PUMA=true\` (which spawns 4 more subprocesses), that's **6 Ruby processes inside a 512 MB container**:

| process              | RSS    |
|----------------------|--------|
| Puma master          | ~150MB |
| Puma worker (forked) | ~150MB |
| SQ supervisor        | ~80MB  |
| SQ dispatcher        | ~80MB  |
| SQ worker            | ~80MB  |
| SQ scheduler         | ~80MB  |
| **total**            | **~620MB → exceeds 512MB → OOM-loop** |

\`WEB_CONCURRENCY=0\` puts Puma in single mode (master serves HTTP directly, no fork). That removes the ~150 MB worker process and brings steady-state RSS under the cap. There's no throughput cost — cluster mode with a single worker is pure overhead anyway, since one Puma process is doing the serving either way.

## How this surfaced
[raghubetina/aplace](https://github.com/raghubetina/aplace) is running the same config (Puma cluster + \`SOLID_QUEUE_IN_PUMA\` on Render Starter, also 512 MB). After a routine deploy the container started OOM-restarting every ~90 seconds while still reporting \`live\` status — HTTP returned 502 most of the time. Render's memory metric showed the sawtooth pattern (~230 MB at boot → ~530 MB at OOM-kill → restart). Fixed by the same one-line change. See [raghubetina/aplace#54](https://github.com/raghubetina/aplace/pull/54).

Any student project that forks this template and adds nontrivial gems (image_processing, ML/embedding clients, etc.) will hit the same wall — worth fixing in the template before more forks inherit it.

## Test plan
- [ ] Deploy a fresh project from this template after the change — \`render.yaml\` should provision a service that boots and stays alive.
- [ ] Memory should hover well under 400 MB instead of bouncing off 512 MB.